### PR TITLE
DT-9127: distribute datafy-controller

### DIFF
--- a/templates/controller.yaml
+++ b/templates/controller.yaml
@@ -49,6 +49,13 @@ spec:
       tolerations:
         {{- toYaml .Values.controller.tolerations | nindent 8 }}
       {{- end }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: datafy-controller
       containers:
         - name: controller
           image: "{{ .Values.controller.image.repository }}:{{ include "datafy-agent.controllerImageTag" . }}"

--- a/values.yaml
+++ b/values.yaml
@@ -103,6 +103,17 @@ controller:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
   affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - datafy-controller
+            topologyKey: kubernetes.io/hostname
   ## @param controller.nodeSelector Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   ##

--- a/values.yaml
+++ b/values.yaml
@@ -103,17 +103,6 @@ controller:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
   affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                    - datafy-controller
-            topologyKey: kubernetes.io/hostname
   ## @param controller.nodeSelector Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   ##


### PR DESCRIPTION
This pull request introduces improvements to the Kubernetes deployment configuration for the `datafy-controller` to enhance pod scheduling and distribution. The changes add anti-affinity and topology spread constraints to encourage even distribution of pods across nodes and reduce the likelihood of scheduling multiple controller pods on the same node.
