### PR TITLE
DT-9127: datafy controller hc

### DIFF
--- a/templates/controller.yaml
+++ b/templates/controller.yaml
@@ -106,15 +106,27 @@ spec:
               containerPort: 9443
             - name: grpc
               containerPort: 50051
-          {{- if .Values.controller.readinessProbe.enabled }}
+            - name: health
+              containerPort: 8081
+          {{- if .Values.controller.health.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: {{ .Values.controller.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.health.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.health.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.health.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.health.livenessProbe.failureThreshold }}
           readinessProbe:
-            grpc:
-              port: 50051
-            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: {{ .Values.controller.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.health.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.health.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.health.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.health.readinessProbe.failureThreshold }}
           {{- end }}
           volumeMounts:
             - name: datafy-controller-config

--- a/templates/controller.yaml
+++ b/templates/controller.yaml
@@ -120,7 +120,7 @@ spec:
             failureThreshold: {{ .Values.controller.health.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: /healthz
               port: health
             initialDelaySeconds: {{ .Values.controller.health.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.controller.health.readinessProbe.periodSeconds }}

--- a/templates/controller.yaml
+++ b/templates/controller.yaml
@@ -106,6 +106,16 @@ spec:
               containerPort: 9443
             - name: grpc
               containerPort: 50051
+          {{- if .Values.controller.readinessProbe.enabled }}
+          readinessProbe:
+            grpc:
+              port: 50051
+            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+          {{- end }}
           volumeMounts:
             - name: datafy-controller-config
               mountPath: /etc/datafy-controller

--- a/values.yaml
+++ b/values.yaml
@@ -99,6 +99,17 @@ controller:
     repository: public.ecr.aws/datafy-io/datafy-controller
     tag:
 
+  ## @param controller.readinessProbe
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+
   ## @param controller.affinity Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##

--- a/values.yaml
+++ b/values.yaml
@@ -102,13 +102,20 @@ controller:
   ## @param controller.readinessProbe
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
   ##
-  readinessProbe:
+  health:
     enabled: true
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    timeoutSeconds: 5
-    successThreshold: 1
-    failureThreshold: 3
+    livenessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 20
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
 
   ## @param controller.affinity Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/values.yaml
+++ b/values.yaml
@@ -105,17 +105,17 @@ controller:
   health:
     enabled: true
     livenessProbe:
-      initialDelaySeconds: 10
-      periodSeconds: 20
+      initialDelaySeconds: 20
+      periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
-      failureThreshold: 3
+      failureThreshold: 5
     readinessProbe:
       initialDelaySeconds: 10
       periodSeconds: 10
       timeoutSeconds: 5
       successThreshold: 1
-      failureThreshold: 3
+      failureThreshold: 2
 
   ## @param controller.affinity Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
This pull request adds configurable health checks to the controller deployment, improving observability and reliability by introducing liveness and readiness probes. The changes include updates to the Helm chart template and default values to support these probes.