### PR TITLE
Release chart update 1.35.5_1.2.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datafy-agent
-version: 3.3.4
-appVersion: 1.35.4_1.2.0
+version: 3.3.5
+appVersion: 1.35.5_1.2.0
 home: https://datafy.io
 maintainers:
   - name: Datafy.io, Inc. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # datafy-agent
 
-![Version: 3.3.4](https://img.shields.io/badge/Version-3.3.4-informational?style=flat-square) ![AppVersion: 1.35.4_1.2.0](https://img.shields.io/badge/AppVersion-1.35.4_1.2.0-informational?style=flat-square)
+![Version: 3.3.5](https://img.shields.io/badge/Version-3.3.5-informational?style=flat-square) ![AppVersion: 1.35.5_1.2.0](https://img.shields.io/badge/AppVersion-1.35.5_1.2.0-informational?style=flat-square)
 
 **App Version:**
 
-1.35.4_1.2.0
+1.35.5_1.2.0
 
 This guide explains how to add the Datafy Helm repo and install the `datafy-agent`.
 
@@ -29,7 +29,7 @@ helm repo update
 
 ### 2. Install
 ```bash
-helm install datafy-agent --version 3.3.4 datafyio/datafy-agent \
+helm install datafy-agent --version 3.3.5 datafyio/datafy-agent \
 --namespace datafy-agent --create-namespace \
 --set agent.mode="sensor/autoscaler" \
 --set agent.token=<your_token> \
@@ -39,12 +39,12 @@ helm install datafy-agent --version 3.3.4 datafyio/datafy-agent \
 ## Upgrade
 ```bash
 helm repo update
-helm upgrade --install datafy-agent --version 3.3.4 datafyio/datafy-agent -n <namespace> --reuse-values --atomic
+helm upgrade --install datafy-agent --version 3.3.5 datafyio/datafy-agent -n <namespace> --reuse-values --atomic
 ```
 
 Switch mode:
 ```bash
-helm upgrade --install datafy-agent --version 3.3.4 datafyio/datafy-agent -n <namespace> --set agent.mode=autoscaler --atomic
+helm upgrade --install datafy-agent --version 3.3.5 datafyio/datafy-agent -n <namespace> --set agent.mode=autoscaler --atomic
 ```
 
 Rollback:


### PR DESCRIPTION
Automated chart update from `release.yaml`.

- appVersion: `1.35.5_1.2.0`
- chart version bump: `3.3.4` -> `3.3.5`
- semantic bump type: `patch`