### PR TITLE
Release chart update 1.35.3_1.3.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datafy-agent
-version: 3.3.2
-appVersion: 1.35.2_1.3.0
+version: 3.3.3
+appVersion: 1.35.3_1.3.0
 home: https://datafy.io
 maintainers:
   - name: Datafy.io, Inc. All Rights Reserved.


### PR DESCRIPTION
Automated chart update.

- appVersion: `1.35.3_1.3.0`
- chart version bump: `3.3.2` -> `3.3.3`
- semantic bump type: `patch`