### PR TITLE
Release chart update 1.35.5_1.3.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datafy-agent
-version: 3.3.4
-appVersion: 1.35.4_1.3.0
+version: 3.3.5
+appVersion: 1.35.5_1.3.0
 home: https://datafy.io
 maintainers:
   - name: Datafy.io, Inc. All Rights Reserved.


### PR DESCRIPTION
Automated chart update.

- appVersion: `1.35.5_1.3.0`
- chart version bump: `3.3.4` -> `3.3.5`
- semantic bump type: `patch`