### PR TITLE
DT-9572: harden agent DaemonSet shutdown lifecycle

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: datafy-agent
-version: 3.3.1
-appVersion: 1.35.1_1.3.0
+version: 3.3.2
+appVersion: 1.36.1_1.4.0
 home: https://datafy.io
 maintainers:
   - name: Datafy.io, Inc. All Rights Reserved.

--- a/templates/agent.yaml
+++ b/templates/agent.yaml
@@ -59,6 +59,11 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /datafy/prestop.sh
           env:
             - name: DATAFY_DSO_URL
               value: {{ .Values.agent.dsoUrl }}
@@ -158,7 +163,7 @@ spec:
       priorityClassName: system-node-critical
       restartPolicy: Always
       schedulerName: default-scheduler
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 90
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}


### PR DESCRIPTION
Add core preStop marker invocation and increase terminationGracePeriodSeconds to 90s so bootstrap-driven shell/core shutdown coordination has enough time to complete while preserving BR pod-vs-host shutdown discrimination.