### PR TITLE
DT-9594: webhook filter

### DIFF
--- a/templates/controller-webhook-secret.yaml
+++ b/templates/controller-webhook-secret.yaml
@@ -52,6 +52,7 @@ webhooks:
           operator: "NotIn"
           values:
             - datafy-controller
+            - datafy-agent
             - aws-cluster-autoscaler
             - aws-node
         - key: "k8s-app"

--- a/templates/controller-webhook-secret.yaml
+++ b/templates/controller-webhook-secret.yaml
@@ -52,6 +52,12 @@ webhooks:
           operator: "NotIn"
           values:
             - datafy-controller
+            - aws-cluster-autoscaler
+            - aws-node
+        - key: "k8s-app"
+          operator: "NotIn"
+          values:
+            - kube-dns
             - kube-proxy
             - coredns
             - aws-node


### PR DESCRIPTION
Properly exclude datafy agent and critical k8s pods