### PR TITLE
DT-10241: inject NODE_NAME into the core container

### DIFF
--- a/templates/agent.yaml
+++ b/templates/agent.yaml
@@ -70,6 +70,10 @@ spec:
                 command:
                   - /datafy/prestop.sh
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: DATAFY_DSO_URL
               value: {{ .Values.agent.dsoUrl }}
             - name: DATAFY_TOKEN


### PR DESCRIPTION
bootstrap.sh's br_node_shutting_down needs the node name to read this node's own object from the apiserver for the shutdown condition.