### PR TITLE
DT-10771: pod drain before agent remove

### DIFF
--- a/templates/controller-webhook-secret.yaml
+++ b/templates/controller-webhook-secret.yaml
@@ -73,7 +73,7 @@ webhooks:
     admissionReviewVersions: [ "v1" ]
     sideEffects: NoneOnDryRun
     failurePolicy: Ignore
-    timeoutSeconds: 5
+    timeoutSeconds: 30
     matchPolicy: Equivalent
     rules:
       - apiGroups: [ "" ]


### PR DESCRIPTION
Increase timeout of the webhook that responds to agent uninstall to allow pods to drain before the agent is removed