### PR TITLE
DT-11266: label controller-owned resources with an install identity

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: datafy-agent
-version: 4.0.0
+version: 4.1.0
 appVersion: 2.0.0_2.0.0
 home: https://datafy.io
 maintainers:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -273,6 +273,39 @@ Render proxy env vars (HTTPS_PROXY/NO_PROXY plus lowercase).
 {{- end -}}
 
 {{/*
+Install identity.
+
+Marks a resource as belonging to whichever install currently owns it. The
+controller replaces "unclaimed" with the install marker ConfigMap's UID, and only
+ever deletes resources carrying its own UID — so a controller left running by a
+previous install cannot tear down the release that replaced it (DT-11266).
+
+The value is a constant on purpose. The identity has to be unique per install and
+stable across upgrades, which is exactly the marker's UID, and that is assigned by
+the API server — no render-time value can be it. Generating one with `lookup` was
+the alternative, and it does not survive this chart's install paths: `helm template`
+has no cluster access, so under Argo CD (see the sync-options annotations on the
+kept resources) a random ID would be reissued on every sync, rewriting every label
+and rolling the controller Deployment continuously.
+
+Rendering the constant is what makes the hand-off safe. `helm uninstall` leaves the
+kept resources behind still carrying the previous install's UID; the next install
+adopts them and writes this manifest, which resets them to "unclaimed" as part of
+the install itself. The previous install's controller stops matching them at that
+moment, with no window to race. On upgrade the label is unchanged between the old
+and new manifests, so helm's three-way merge leaves the live claim alone.
+
+"unclaimed" matches no controller, so the failure direction is always a resource
+nobody deletes, never a resource the wrong install deletes.
+
+Deliberately outside the kustomize guard below: a kustomize-rendered install would
+otherwise get no label at all and fall back to name-based teardown.
+*/}}
+{{- define "datafy-agent.installIdLabel" -}}
+datafy.io/install-id: unclaimed
+{{- end -}}
+
+{{/*
 Common labels for all resources
 */}}
 {{- define "datafy-agent.labels" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -273,33 +273,22 @@ Render proxy env vars (HTTPS_PROXY/NO_PROXY plus lowercase).
 {{- end -}}
 
 {{/*
-Install identity.
+Install identity. The controller replaces "unclaimed" with the install marker's
+UID and only deletes resources carrying its own UID, so a controller left running
+by a previous install cannot tear down the release that replaced it (DT-11266).
 
-Marks a resource as belonging to whichever install currently owns it. The
-controller replaces "unclaimed" with the install marker ConfigMap's UID, and only
-ever deletes resources carrying its own UID — so a controller left running by a
-previous install cannot tear down the release that replaced it (DT-11266).
+A constant, not a generated ID: the identity must be unique per install and stable
+across upgrades, which is the marker's UID, and only the API server can assign it.
+`lookup` cannot substitute — `helm template` has no cluster access, so under Argo CD
+a random ID would be reissued on every sync.
 
-The value is a constant on purpose. The identity has to be unique per install and
-stable across upgrades, which is exactly the marker's UID, and that is assigned by
-the API server — no render-time value can be it. Generating one with `lookup` was
-the alternative, and it does not survive this chart's install paths: `helm template`
-has no cluster access, so under Argo CD (see the sync-options annotations on the
-kept resources) a random ID would be reissued on every sync, rewriting every label
-and rolling the controller Deployment continuously.
+The constant is also what makes the hand-off safe. An uninstall leaves kept
+resources carrying the previous UID; the next install adopts them and writes this
+manifest, resetting them to "unclaimed" as part of the install itself. On upgrade
+the label is unchanged between manifests, so helm's three-way merge leaves a live
+claim alone.
 
-Rendering the constant is what makes the hand-off safe. `helm uninstall` leaves the
-kept resources behind still carrying the previous install's UID; the next install
-adopts them and writes this manifest, which resets them to "unclaimed" as part of
-the install itself. The previous install's controller stops matching them at that
-moment, with no window to race. On upgrade the label is unchanged between the old
-and new manifests, so helm's three-way merge leaves the live claim alone.
-
-"unclaimed" matches no controller, so the failure direction is always a resource
-nobody deletes, never a resource the wrong install deletes.
-
-Deliberately outside the kustomize guard below: a kustomize-rendered install would
-otherwise get no label at all and fall back to name-based teardown.
+Outside the kustomize guard below, which would otherwise render no label at all.
 */}}
 {{- define "datafy-agent.installIdLabel" -}}
 datafy.io/install-id: unclaimed

--- a/templates/controller-config.yaml
+++ b/templates/controller-config.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false

--- a/templates/controller-rbac.yaml
+++ b/templates/controller-rbac.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false
@@ -22,6 +23,7 @@ metadata:
   name: {{ $roleName }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false
@@ -55,6 +57,13 @@ rules:
     resources: [ "configmaps" ]
     resourceNames: [ "datafy-volume-replacements", "datafy-controller-config" ]
     verbs: [ "get", "update", "patch", "delete" ]
+  # list is what lets the controller find its own resources by the datafy.io/install-id
+  # label rather than by hard-coded name. RBAC cannot constrain a collection request by
+  # name, so list is necessarily unrestricted; the delete below stays name-scoped.
+  # Every other kind the controller sweeps already has list/watch elsewhere in this role.
+  - apiGroups: [ "" ]
+    resources: [ "services" ]
+    verbs: [ "list", "watch" ]
   - apiGroups: [ "" ]
     resources: [ "services" ]
     resourceNames: [ "datafy-controller", "datafy-controller-webhook" ]
@@ -143,6 +152,7 @@ metadata:
   name: {{ $roleBindingName }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false

--- a/templates/controller-rbac.yaml
+++ b/templates/controller-rbac.yaml
@@ -57,10 +57,9 @@ rules:
     resources: [ "configmaps" ]
     resourceNames: [ "datafy-volume-replacements", "datafy-controller-config" ]
     verbs: [ "get", "update", "patch", "delete" ]
-  # list is what lets the controller find its own resources by the datafy.io/install-id
-  # label rather than by hard-coded name. RBAC cannot constrain a collection request by
-  # name, so list is necessarily unrestricted; the delete below stays name-scoped.
-  # Every other kind the controller sweeps already has list/watch elsewhere in this role.
+  # list lets the controller find its own resources by the datafy.io/install-id label
+  # instead of by name. RBAC cannot constrain a collection request by name, so it is
+  # necessarily unrestricted; the delete below stays name-scoped.
   - apiGroups: [ "" ]
     resources: [ "services" ]
     verbs: [ "list", "watch" ]

--- a/templates/controller-webhook.yaml
+++ b/templates/controller-webhook.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false
@@ -22,6 +23,7 @@ metadata:
   name: datafy-controller-webhook
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false

--- a/templates/controller.yaml
+++ b/templates/controller.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false
@@ -157,6 +158,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false
@@ -178,6 +180,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
   {{- with .Values.extraAnnotations }}

--- a/templates/datafy-token.yaml
+++ b/templates/datafy-token.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false

--- a/templates/volumes-replacements.yaml
+++ b/templates/volumes-replacements.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "datafy-agent.labels" . | nindent 4 }}
+  {{- include "datafy-agent.installIdLabel" . | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: Delete=false


### PR DESCRIPTION
Jira: [DT-11266](https://datafyio.atlassian.net/browse/DT-11266)

Chart half of the DT-11266 fix. **Inert on its own** — it adds a label nothing reads yet, plus one RBAC verb. The controller change that consumes it lands separately in `k8s-csi-controller`, and keys off the label's presence, so there is no ordering requirement between the two and no minimum chart version to enforce.

## Why

`helm uninstall` does not stop the controller — the chart keeps its Deployment so the transparent wind-down can run. A controller from a previous install can therefore still act on the namespace after its successor is live, and it decided what to delete **by name**. Every install renders the same names, so nothing in that decision could distinguish one install's resources from another's.

In the incident that cost a live install its `datafy-token` secret, the webhook configuration, both Services and — via the ClusterRoleBinding cascade — the controller Deployment itself, ten minutes after a healthy install.

## What this adds

- `datafy.io/install-id: unclaimed` on the resources the controller can delete. The controller rewrites it to the install marker ConfigMap's UID and will only delete resources carrying its own UID.
- `list`/`watch` on `services` — the only swept kind that lacked it. RBAC cannot constrain a collection request by name, so `list` is necessarily unrestricted; deletes stay `resourceNames`-scoped.
- Chart `4.0.0` → `4.1.0`.

## Two decisions worth reviewing

**Why a constant and not a generated ID.** The identity has to be unique per install and stable across upgrades — that is exactly the marker's UID, and only the API server can assign it. Generating one with `lookup` was the alternative and it does not survive this chart's install paths: `helm template` has no cluster access, so under Argo CD (see the `sync-options` annotations on the kept resources) a random ID would be reissued on every sync, rewriting every label and rolling the controller Deployment continuously.

Rendering the constant is also what makes the hand-off safe rather than racy. An uninstall leaves the kept resources carrying the previous install's UID; the next install adopts them and writes this manifest, resetting them to `unclaimed` **as part of the install itself**. The previous controller stops matching them at that moment — no window. On upgrade the label is unchanged between manifests, so helm's three-way merge leaves a live claim alone.

`unclaimed` matches no controller, so the failure direction is always "a resource nobody deletes", never "a resource the wrong install deletes".

**Why not the shared label helper.** `datafy-agent.labels` is also used for the agent DaemonSet's **pod template**. Adding a label there would change the pod template hash and roll every agent pod on upgrade — the exact disruption this ticket opens with. So the stamp is applied explicitly to the controller-owned resources instead, which also makes the change reviewable: the stamped set is precisely the set the controller may delete.

## Verification

`helm lint` clean. Rendered and confirmed the label lands on the ServiceAccount, ClusterRole, ClusterRoleBinding, controller Deployment, both Services, the MutatingWebhookConfiguration, both ConfigMaps and both Secrets — and that the agent DaemonSet, its pod template and the agent RBAC are untouched.

## Note for Argo CD users

A sync resets the label to `unclaimed` and the controller re-claims it within a resync. That churn is cosmetic and fails safe, but it will show as OutOfSync; `ignoreDifferences` on this label silences it. Worth deciding whether to document that in the README before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DT-11266]: https://datafyio.atlassian.net/browse/DT-11266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ